### PR TITLE
base_name -> basename

### DIFF
--- a/docs/viewsets.rst
+++ b/docs/viewsets.rst
@@ -16,9 +16,9 @@ For use with ViewSets and Routers, **drf-multiple-model** provides the ``ObjectM
         ]
 
      router = routers.SimpleRouter()
-     router.register('texts', TextAPIView, base_name='texts')
+     router.register('texts', TextAPIView, basename='texts')
 
 
-**WARNING:** Because the ObjectMultipleModel views do not provide the ``queryset`` property, you **must** specify the ``base_name`` property when you register a ``ObjectMultipleModelAPIViewSet`` with a router. 
+**WARNING:** Because the ObjectMultipleModel views do not provide the ``queryset`` property, you **must** specify the ``basename`` property when you register a ``ObjectMultipleModelAPIViewSet`` with a router. 
 
 The ``ObjectMultipleModelAPIViewSet`` has all the same configuration options as the ``ObjectMultipleModelAPIView`` object.  For more information, see the :doc:`basic usage <basic-usage>` section. 


### PR DESCRIPTION
Deprecate (https://www.django-rest-framework.org/community/release-notes/#390) the Router.register base_name argument in favor of basename. #5990 (https://github.com/encode/django-rest-framework/issues/5990)