### PR TITLE
Typo in ObjectMultipleModelAPIView Documentation

### DIFF
--- a/docs/object-options.rst
+++ b/docs/object-options.rst
@@ -5,19 +5,19 @@ ObjectMultipleModelAPIView Options
 Labels
 ======
 
-By default, ``ObjectMultipleModelAPIView`` uses the model name as a label. If you want to use a custom label, you can add a ``label`` key to your ``querylist`` dicts, like so::
+By default, ``ObjectMultipleModelAPIView`` uses the model name as a label. If you want to use a custom label, you can add a ``label`` key to your ``queryset`` dicts, like so::
 
     from drf_multiple_model.views import ObjectMultipleModelAPIView
 
     class TextAPIView(ObjectMultipleModelAPIView):
         querylist = [
             {
-                'querylist': Play.objects.all(),
+                'queryset': Play.objects.all(),
                 'serializer_class': PlaySerializer,
                 'label': 'drama',
             },
             {
-                'querylist': Poem.objects.filter(style='Sonnet'),
+                'queryset': Poem.objects.filter(style='Sonnet'),
                 'serializer_class': PoemSerializer,
                 'label': 'sonnets'
             },


### PR DESCRIPTION
I followed the documentation and got a 'Error: there should be a  queryset key' . So, please change the documentation accordingly.