### PR TITLE
Fix Travis build error associated with `importlib_metadata`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
    - DJANGO="Django<2"
    - DJANGO="Django<2.1"
    - DJANGO="Django<2.2"
+before_install:
+ - if [[$TRAVIS_PYTHON_VERSION == 3.7]]; then pip install -U importlib_metadata ; fi
 install:
  - pip install "$DJANGO" coverage coveralls "djangorestframework>=3.9" flake8
  - pip install .


### PR DESCRIPTION
`importlib_metadata` is causing errors installing dependency on Python 3.7 only.

Example build failure: [link](https://app.travis-ci.com/github/MattBroach/DjangoRestMultipleModels/jobs/578823288)

This proposed fix is based on discussions on the Travis CI community [here](https://travis-ci.community/t/build-error-for-python-3-7-on-two-different-projects/12895/3) and [here](https://travis-ci.community/t/build-errors-installing-a-common-dependency-docopt-on-python-3-7-but-not-other-versions/12886/5). Though I am unsure how to test this properly.